### PR TITLE
Ignore update_*.php helper files in license check

### DIFF
--- a/check-smf-license.php
+++ b/check-smf-license.php
@@ -42,6 +42,8 @@ $ignoreFiles = array(
 	// Cache and miscellaneous.
 	'\./cache/',
 	'\./other/db_last_error\.php',
+	'\./other/update_version_numbers.php',
+	'\./other/update_unicode_data.php',
 	'\./tests/',
 	'\./vendor/',
 


### PR DESCRIPTION
This change should fix [this build problem](https://github.com/SimpleMachines/SMF/actions/runs/3331254809/jobs/5510777628).